### PR TITLE
Jacklinton patch 1

### DIFF
--- a/exercise-01-solution/package.json
+++ b/exercise-01-solution/package.json
@@ -17,6 +17,7 @@
     "react": "^15.4.2",
     "react-apollo": "^1.0.0-rc.2",
     "react-native": "0.41.2",
+    "react-native-experimental-navigation": "0.26.10",
     "react-native-router-flux": "^3.37.0"
   },
   "devDependencies": {

--- a/exercise-01/package.json
+++ b/exercise-01/package.json
@@ -17,6 +17,7 @@
     "react": "^15.4.2",
     "react-apollo": "^1.0.0-rc.2",
     "react-native": "0.41.2",
+    "react-native-experimental-navigation": "0.26.10",
     "react-native-router-flux": "^3.37.0"
   },
   "devDependencies": {

--- a/exercise-02-solution/package.json
+++ b/exercise-02-solution/package.json
@@ -17,6 +17,7 @@
     "react": "^15.4.2",
     "react-apollo": "^1.0.0-rc.2",
     "react-native": "0.41.2",
+    "react-native-experimental-navigation": "0.26.10",
     "react-native-router-flux": "^3.37.0"
   },
   "devDependencies": {

--- a/exercise-02/package.json
+++ b/exercise-02/package.json
@@ -17,6 +17,7 @@
     "react": "^15.4.2",
     "react-apollo": "^1.0.0-rc.2",
     "react-native": "0.41.2",
+    "react-native-experimental-navigation": "0.26.10",
     "react-native-router-flux": "^3.37.0"
   },
   "devDependencies": {

--- a/exercise-03-solution/package.json
+++ b/exercise-03-solution/package.json
@@ -17,6 +17,7 @@
     "react": "^15.4.2",
     "react-apollo": "^1.0.0-rc.2",
     "react-native": "0.41.2",
+    "react-native-experimental-navigation": "0.26.10",
     "react-native-router-flux": "^3.37.0"
   },
   "devDependencies": {

--- a/exercise-03/package.json
+++ b/exercise-03/package.json
@@ -17,6 +17,7 @@
     "react": "^15.4.2",
     "react-apollo": "^1.0.0-rc.2",
     "react-native": "0.41.2",
+    "react-native-experimental-navigation": "0.26.10",
     "react-native-router-flux": "^3.37.0"
   },
   "devDependencies": {

--- a/exercise-04-solution/package.json
+++ b/exercise-04-solution/package.json
@@ -17,6 +17,7 @@
     "react": "^15.4.2",
     "react-apollo": "^1.0.0-rc.2",
     "react-native": "0.41.2",
+    "react-native-experimental-navigation": "0.26.10",
     "react-native-router-flux": "^3.37.0"
   },
   "devDependencies": {

--- a/exercise-04/package.json
+++ b/exercise-04/package.json
@@ -17,6 +17,7 @@
     "react": "^15.4.2",
     "react-apollo": "^1.0.0-rc.2",
     "react-native": "0.41.2",
+    "react-native-experimental-navigation": "0.26.10",
     "react-native-router-flux": "^3.37.0"
   },
   "devDependencies": {

--- a/exercise-05-solution/package.json
+++ b/exercise-05-solution/package.json
@@ -17,6 +17,7 @@
     "react": "^15.4.2",
     "react-apollo": "^1.0.0-rc.2",
     "react-native": "0.41.2",
+    "react-native-experimental-navigation": "0.26.10",
     "react-native-router-flux": "^3.37.0"
   },
   "devDependencies": {

--- a/exercise-05/package.json
+++ b/exercise-05/package.json
@@ -17,6 +17,7 @@
     "react": "^15.4.2",
     "react-apollo": "^1.0.0-rc.2",
     "react-native": "0.41.2",
+    "react-native-experimental-navigation": "0.26.10",
     "react-native-router-flux": "^3.37.0"
   },
   "devDependencies": {

--- a/exercise-06-solution/package.json
+++ b/exercise-06-solution/package.json
@@ -17,6 +17,7 @@
     "react": "^15.4.2",
     "react-apollo": "^1.0.0-rc.2",
     "react-native": "0.41.2",
+    "react-native-experimental-navigation": "0.26.10",
     "react-native-router-flux": "^3.37.0"
   },
   "devDependencies": {

--- a/exercise-06/package.json
+++ b/exercise-06/package.json
@@ -17,6 +17,7 @@
     "react": "^15.4.2",
     "react-apollo": "^1.0.0-rc.2",
     "react-native": "0.41.2",
+    "react-native-experimental-navigation": "0.26.10",
     "react-native-router-flux": "^3.37.0"
   },
   "devDependencies": {


### PR DESCRIPTION
There is a bug in react-native-experimental-navigation version 0.26.11 that prevents users from navigating to the PokemonPages. I added the dependency for the previous version all package.json files to fix the error and allow normal usage of the program, at least in iOS.